### PR TITLE
Compare TF and keras workflows, add node interpretation

### DIFF
--- a/node_interpretation/pathway_enrichment.R
+++ b/node_interpretation/pathway_enrichment.R
@@ -1,0 +1,253 @@
+################################################################################
+# This script provides several helper functions for pathway enrichment analysis
+#
+# Usage:
+#        It should be imported by other scripts.
+################################################################################
+#library(pacman)
+#pacman::p_load("readr")
+#source(file.path("..", "node_interpretation", "signature_helper.R"))
+source('node_interpretation/signature_helper.R')
+
+enrichment.test <- function(gene.set, pathway.terms, geneN){
+  # This function tests pathway enrichment for a gene set on a group of
+  # pathway terms.
+  #
+  # Inputs:
+  # gene.set: a vector contains genes in the gene set to test
+  # pathway.terms: a data.frame read from the pseudomonas_KEGG_terms.txt
+  # geneN: number of all possible genes
+
+  pvalue_list <- c()
+  # loop through pathway terms
+  for (term in 1:nrow(pathway.terms)) {
+    # get genes in one pathway term
+    term_genes <- unlist(strsplit(pathway.terms[term, 2], ";"))
+   # print(length(gene.set))
+    test_result <- enrich_test(gene.set, term_genes, geneN)
+    # get p value
+    pvalue <- test_result$p.value
+    pvalue_list <- c(pvalue_list, pvalue)
+  }
+  return(pvalue_list)
+}
+
+
+test.one.model <- function(weight_matrix, pathway, HW_cutoff) {
+  # This function tests pathway enrichment for all nodes in an ADAGE model.
+  #
+  # Inputs:
+  # weight_matrix: a data.matrix that stores weights of an ADAGE model
+  # pathway: a data.frame read from the pseudomonas_KEGG_terms.txt
+  # HW_cutoff: the number of standard deviations from mean to be considered as
+  #            high-weight
+  # Output:
+  # pvalue_table: a data.frame that stores the enrichment results between each
+  #               node and each pathway
+
+  nodeN <- ncol(weight_matrix)
+  geneN <- nrow(weight_matrix)
+  #print(dim(weight_matrix))
+  pvalue_table <- list()
+  for (node in 1:nodeN) {
+
+    # get high-weight genes at pos and neg sides
+    pos_cutoff <- mean(weight_matrix[, node]) +
+      HW_cutoff * sd(weight_matrix[, node])
+    neg_cutoff <- mean(weight_matrix[, node]) -
+      HW_cutoff * sd(weight_matrix[, node])
+    HW_genes_pos <- rownames(weight_matrix)[weight_matrix[, node] >= pos_cutoff]
+    HW_genes_neg <- rownames(weight_matrix)[weight_matrix[, node] <= neg_cutoff]
+
+    # pathway enrichment analysis for positive high-weight genes
+    #print(length(HW_genes_pos))
+    #print(length(HW_genes_neg))
+    pvalue_list <- enrichment.test(HW_genes_pos, pathway, geneN)
+    this_table_pos <- data.frame(node = paste("Node", rep(node, nrow(pathway))),
+                                 side = rep("pos", nrow(pathway)),
+                                 pathway = rownames(pathway),
+                                 pvalue = pvalue_list)
+
+    # pathway enrichment analysis for negative high-weight genes
+    pvalue_list <- enrichment.test(HW_genes_neg, pathway, geneN)
+    this_table_neg <- data.frame(node = paste("Node", rep(node, nrow(pathway))),
+                                 side = rep("neg", nrow(pathway)),
+                                 pathway = rownames(pathway),
+                                 pvalue = pvalue_list)
+
+    # combine pos and neg sides
+    this_table <- rbind(this_table_pos, this_table_neg)
+
+    # FDR correction
+    this_table$pvalue <- as.numeric(as.character(this_table$pvalue))
+    this_table$qvalue <- p.adjust(this_table$pvalue, method = "fdr")
+    pvalue_table[[node]] <- this_table
+  }
+  pvalue_table <- do.call(rbind, pvalue_table)
+
+  return (pvalue_table)
+}
+
+
+one.pathway.analysis <- function(netfile, geneID, pathway, outfile1,
+                                 outfile2, HW_cutoff, sig_cutoff,
+                                 component = FALSE, output_all = FALSE){
+  # This function reads in an ADAGE model from a file, performs pathway
+  # enrichment analysis, and write the output into files.
+  #
+  # Inputs:
+  # netfile: file path to the network file of an ADAGE model
+  # geneID: the gene IDs that correspond to each row of an ADAGE weight matrix
+  # pathway: a data.frame read from the pseudomonas_KEGG_terms.txt
+  # outfile1: file path to output file that stores only significant enrichment
+  #           results
+  # outfile2: file path to output file that stores all tested node-pathway
+  #           associations
+  # HW_cutoff: float, number of standard deviations from mean to be considered
+  #            as high-weight
+  # sig_cutoff: float, significance cutoff of FDR q-values
+  # component: boolean, whether each column in the weight matrix represent a
+  #            component in PCA or ICA model
+  # output_all: boolean, whether to write outfile2 that stores every enrichment
+  #             test
+  #print('one.pathway.analysis')
+  # load the weight matrix
+  geneN = nrow(geneID)
+  weight = read_delim(netfile, delim = ',', col_names = F, n_max = geneN,
+                      skip = 0)
+  #weight = read_delim(netfile, delim = '\t', col_names = F, n_max = geneN,
+  #                    skip = 4)
+  #print(dim(weight))
+  #print(weight[1,1])
+  weight_matrix <- data.matrix(weight[1:geneN, ])
+  rownames(weight_matrix) = geneID$X
+  #print(geneID$X[1])
+  # test pathway association between all nodes in a model and all pathways
+  #print(dim(pathway))
+  #print(pathway[1,1])
+  pvalue_table <- test.one.model(weight_matrix, pathway, HW_cutoff)
+  #print(dim(pvalue_table))
+  if (component) {
+    # rename node to component for PCA and ICA models
+    colnames(pvalue_table)[1] = 'component'
+  }
+
+  # get significant results and write to file
+  pvalue_table_sig = pvalue_table[which(pvalue_table$qvalue <= sig_cutoff), ]
+  #print(dim(pvalue_table_sig))
+  write.table(pvalue_table_sig, outfile1, col.names = T, row.names = F,
+              quote = F, sep = '\t')
+
+  if (output_all) {
+    # output all results including non significant associations
+    write.table(pvalue_table, outfile2, col.names = T, row.names = F, quote = F,
+                sep = '\t')
+  }
+}
+
+
+multi.pathway.analysis <- function(netfiles, data_file, pathway_file, outfile1,
+                                   outfile2, output_all, type,
+                                   HW_cutoff = 2.5, sig_cutoff = 0.05) {
+  # This function handles multiple ADAGE network files together. It is designed
+  # to perform pathway enrichment analyses for models with different model
+  # sizes (type="netsize"), or trained with different number of samples
+  # (type="subsample"), or multiple ensemble models (type="ensemble"). It will
+  # assemble enrichment results with meta data and write to output files.
+  #
+  # Inputs:
+  # netfiles: file paths to network files of ADAGE models to be analyzed
+  # data_file: file path to the input data compendium that are used to build
+  #            those ADAGE models
+  # pathway_file: file path to the pathway annotation file
+  #               pseudomonas_KEGG_terms.txt
+  # outfile1: file path to output file that stores only significant enrichment
+  #           results
+  # outfile2: file path to output file that stores all tested node-pathway
+  #           associations
+  # output_all: boolean, whether to write outfile2 that stores every enrichment
+  #             test
+  # type: can be "netsize", "corruption", "subsample", "ensemble", or
+  #       "ensembleSize", it determines how the meta data are recorded
+  # HW_cutoff: float, number of standard deviations from mean to be considered
+  #            as high-weight
+  # sig_cutoff: float, significance cutoff of FDR q-values
+
+
+  # check input analysis type
+  if (!type %in% c("netsize", "corruption", "subsample", "ensemble",
+                   "ensembleSize")){
+    stop("Analysis type unknown! Must be netsize, corruption, subsample,
+         ensemble, or ensembleSize.")
+  }
+
+  # count the number of columns in the data file
+  col_n <- count.fields(data_file, sep = ",")[1]
+  # read in the gene IDs from data file
+  geneID <- read.table(data_file, sep = ",", header = T,
+                       colClasses = c("character", rep("NULL", col_n - 1)))
+  geneN <- nrow(geneID)
+  # read in pathway terms
+  pathway <- read.table(pathway_file, sep = "\t", header = F, row.names = 1,
+                        stringsAsFactors = F)
+
+  # the pathway enrichment analysis for each network file runs in parallel
+  all_path <- foreach(i = 1:length(netfiles), .combine = "rbind") %dopar% {
+
+    weight = read_delim(netfiles[i], delim = '\t', col_names = F, n_max = geneN,
+                        skip = 2)
+    weight_matrix <- data.matrix(weight[1:geneN, ])
+    rownames(weight_matrix) <- geneID$Gene_symbol
+
+    pvalue_table <- test.one.model(weight_matrix, pathway, HW_cutoff)
+
+    # get the parameter info from file name
+    parameter_info <- unlist(strsplit(basename(netfiles[i]), "_"))
+    if (type == "subsample") {
+      seed1 <- parameter_info[8]
+      seed2 <- parameter_info[10]
+      samplesize <- parameter_info[12]
+      pvalue_table <- data.frame(samplesize = rep(samplesize, nrow(pvalue_table)),
+                                 seed2 = rep(seed1, nrow(pvalue_table)),
+                                 seed1 = rep(seed2, nrow(pvalue_table)),
+                                 pvalue_table)
+    } else if (type == "netsize") {
+      seed <- parameter_info[8]
+      pvalue_table <- data.frame(seed = rep(seed, nrow(pvalue_table)),
+                                 pvalue_table)
+    } else if (type == "corruption") {
+      seed <- parameter_info[8]
+      corruption <- parameter_info[5]
+      pvalue_table <- data.frame(seed = rep(seed, nrow(pvalue_table)),
+                                 corruption = rep(corruption, nrow(pvalue_table)),
+                                 pvalue_table)
+    } else if (type == "ensemble") {
+      model  <- parameter_info[3]
+      seed <- parameter_info[6]
+      pvalue_table <- data.frame(model = rep(model, nrow(pvalue_table)),
+                                 seed = rep(seed, nrow(pvalue_table)),
+                                 pvalue_table)
+    } else if (type == "ensembleSize") {
+      ensembleSize  <- parameter_info[4]
+      seed <- parameter_info[6]
+      pvalue_table <- data.frame(ensembleSize = rep(ensembleSize,
+                                                    nrow(pvalue_table)),
+                                 seed = rep(seed, nrow(pvalue_table)),
+                                 pvalue_table)
+    }
+
+    pvalue_table
+  }
+
+  all_path$qvalue <- as.numeric(all_path$qvalue)
+  sig_path <- all_path[which(all_path$qvalue <= sig_cutoff), ]
+  # write the significant result table
+  write.table(sig_path, outfile1, col.names = TRUE, row.names = FALSE,
+              quote = FALSE, sep = "\t")
+  if (output_all) {
+    # write the complete result table
+    write.table(all_path, outfile2, col.names = TRUE, row.names = FALSE,
+                quote = FALSE, sep = "\t")
+  }
+}
+

--- a/node_interpretation/pathway_enrichment_analysis.R
+++ b/node_interpretation/pathway_enrichment_analysis.R
@@ -1,0 +1,55 @@
+################################################################################
+# This script does pathway enrichment analysis for one ADAGE/eADAGE model.
+#
+# Usage:
+#     Rscript pathway_enrichment_analysis.R netfile pathway_file data_file
+#     output_prefix output_all HW_cutoff
+#
+#     netfile: the network file of an ensemble model
+#     pathway_file: file path to 'pseudomonas_KEGG_terms.txt' or
+#                   'pseudomonas_GO_terms.txt'
+#     data_file: the training compendium
+#     output_prefix: prefix to output file
+#     output_all: whether the full results including non-significant enrichments
+#                 will be written into files
+#     HW_cutoff: number of standard deviations from the mean to be counted as
+#                high-weight
+################################################################################
+
+#source(file.path("..", "netsize_evaluation", "pathway_enrichment.R"))
+source('node_interpretation/pathway_enrichment.R')
+############# load in arguments
+#print(commandArgs)
+netfile <- commandArgs(trailingOnly = TRUE)[1]
+print(netfile)
+pathway_file <- commandArgs(trailingOnly = TRUE)[2]
+data_file <- commandArgs(trailingOnly = TRUE)[3]
+output_prefix <- commandArgs(trailingOnly = TRUE)[4]
+output_all <- as.logical(commandArgs(trailingOnly = TRUE)[5])
+HW_cutoff <- as.numeric(commandArgs(trailingOnly = TRUE)[6])
+
+###### load in constant
+
+sig_cutoff <- 0.05
+
+############# read in data
+
+# count the number of columns in the data file
+col_n <- count.fields(data_file, sep = "\t")[1]
+# read in the gene IDs from data file
+geneID <- read.table(data_file, sep = ",", header = T,
+                     colClasses = c("character", rep("NULL", col_n - 1)),
+                     skip = 0)
+colnames(geneID)[1]
+# read in the pathway file
+pathway <- read.table(pathway_file, sep = "\t", header = F, row.names = 1,
+                      stringsAsFactors = F)
+# create names of the output files
+outfile1 <- paste0(output_prefix, "_sigPathway.txt")
+outfile2 <- paste0(output_prefix, "_allPathway.txt")
+
+
+############# run analysis
+
+one.pathway.analysis(netfile, geneID, pathway, outfile1, outfile2, HW_cutoff,
+                     sig_cutoff, output_all)

--- a/node_interpretation/signature_helper.R
+++ b/node_interpretation/signature_helper.R
@@ -1,0 +1,138 @@
+#pacman::p_load("readr", "dplyr")
+library(readr)
+library(dplyr)
+
+load_model <- function(model_file, geneID){
+  # This function reads in the ADAGE model file and return the weight matrix
+  # of the model
+  # 
+  # model_file: file path to an ADAGE network file
+  # geneID: gene identifiers correspond to the model
+  # return: a data.frame with the first column being geneID and the rest
+  # columns being node weights.
+
+  model <- readr::read_delim(model_file, delim = "\t", col_names = FALSE,
+                             n_max = nrow(geneID), skip = 2)
+  colnames(model) <- paste0("Node", seq(1, ncol(model)))
+  model <- dplyr::bind_cols(geneID, model)
+  return(model)
+}
+
+
+one_signature <- function(node_weight, geneID, side, HW_cutoff = 2.5){
+  # This function extracts a single gene signature from an ADAGE model.
+  # 
+  # node_weight: a vector storing weight values of each gene to a node
+  # geneID: gene identifiers correspond to the weight vector
+  # side: character, "pos" or "neg"
+  # HW_cutoff: number of standard deviations from mean in a node's weight
+  # distribution to be considered as high-weight (default to 2.5).
+  # return: a character vector storing genes in the signature defined by the
+  # weight vector and the side.
+
+  if (side == "pos") {
+    
+    pos_cutoff <- mean(node_weight) + HW_cutoff * sd(node_weight)
+    print(mean(node_weight))
+    # order positive HW genes from high to low weight
+    HW_order <- order(node_weight, decreasing = TRUE)
+    ordered_node_weight <- node_weight[HW_order]
+    ordered_geneID <- geneID[HW_order]
+    HWG <- ordered_geneID[ordered_node_weight >= pos_cutoff]
+    
+  } else if (side == "neg") {
+    
+    neg_cutoff <- mean(node_weight) - HW_cutoff * sd(node_weight)
+    # order negative HW genes from low to high weight
+    HW_order <- order(node_weight, decreasing = FALSE)
+    ordered_node_weight <- node_weight[HW_order]
+    ordered_geneID <- geneID[HW_order]
+    HWG <- ordered_geneID[ordered_node_weight <= neg_cutoff]
+    
+  } else {
+    stop("side can only be pos or neg.")
+  }
+  
+  return(HWG)
+}
+
+extract_signatures <- function(model, HW_cutoff = 2.5){
+  # This function extracts all signatures of an ADAGE model.
+  #
+  # model: the ADAGE model to be used for extracting signatures
+  # HW_cutoff: number of standard deviations from mean in a node's weight
+  # distribution to be considered as high-weight (default to 2.5). Only
+  # high-weight genes are included in signatures.
+  # return: a named list with each element being a gene signature
+
+  weight_matrix <- as.matrix(model[, -1])
+  model_size <- ncol(weight_matrix)
+  geneID <- as.data.frame(model)[, 1]
+  
+  pos_signatures <- lapply(1:model_size, function(x)
+    one_signature(weight_matrix[, x], geneID, "pos", HW_cutoff))
+  neg_signatures <- lapply(1:model_size, function(x)
+    one_signature(weight_matrix[, x], geneID, "neg", HW_cutoff))
+  
+  signature_list <- c(pos_signatures, neg_signatures)
+  names(signature_list) <- c(paste0("Node", seq(1, model_size), "pos"),
+                             paste0("Node", seq(1, model_size), "neg"))
+  
+  return(signature_list)
+}
+
+
+enrich_test <- function(set1, set2, length_all){
+  # This function performs a one-side fisher exact test to determine whether
+  # two sets of genes have significant overlap.
+  # 
+  # set1: character vector storing genes in the first gene set.
+  # set2: character vector storing genes in the second gene set.
+  # length_all: the number of all possible genes to choose from.
+  # return: object returned by fisher.test() function, which is a list with
+  # class "htest" containing p.value, conf.int, estimate, and so on.
+
+  set_overlap <- length(intersect(set1, set2))
+  set1_only <- length(set1) - set_overlap
+  set2_only <- length(set2) - set_overlap
+  others <- length_all - set_overlap - set2_only - set1_only
+  contingency_table <- matrix(c(set_overlap, set1_only, set2_only, others),
+                              nrow = 2)
+  fisher_result <- fisher.test(contingency_table, alternative='greater')
+  
+  return(fisher_result)
+}
+
+test_signature_overlap <- function(signatures_genes){
+  # This function tests how significant any two combinations of input signatures
+  # overlap with each other in term of their gene compositions.
+  #
+  # model: an ADAGE model to extract signatures from
+  # return: a named list storing adjusted p values in all signature overlap
+  # tests.
+
+  # get unique genes in all signatures
+  all_genes <- unique(unlist(signatures_genes))
+
+  # generate all possible combinations of both signatures' gene lists and names
+  comb_sig <- combn(signatures_genes, 2)
+  comb_name <- combn(names(signatures_genes), 2)
+  
+  # test the significance of overlap between every two signature combinations
+  result_table <- mapply(enrich_test, comb_sig[1, ], comb_sig[2, ],
+                         MoreArgs = list(length_all = length(all_genes)))
+  
+  # name each element with its signature combination
+  colnames(result_table) <- sapply(1: ncol(comb_name),function(x)
+    paste(comb_name[, x], collapse = "_"))
+  
+  # extract odds ratio from the enrichment results
+  p_values <- result_table["p.value", ]
+  
+  # multiple hypothesis correction
+  q_values <- p.adjust(p_values, method = "fdr")
+  
+  return(q_values)
+  
+}
+

--- a/pathway_enrichment.R
+++ b/pathway_enrichment.R
@@ -1,0 +1,258 @@
+################################################################################
+# This script provides several helper functions for pathway enrichment analysis
+#
+# Usage:
+#        It should be imported by other scripts.
+################################################################################
+#library(pacman)
+#install.packages('pacman')
+#pacman::p_load("readr")
+
+#source(file.path("..", "node_interpretation", "signature_helper.R"))
+library(readr)
+
+source('node_interpretation/signature_helper.R')
+
+
+enrichment.test <- function(gene.set, pathway.terms, geneN){
+  # This function tests pathway enrichment for a gene set on a group of
+  # pathway terms.
+  #
+  # Inputs:
+  # gene.set: a vector contains genes in the gene set to test
+  # pathway.terms: a data.frame read from the pseudomonas_KEGG_terms.txt
+  # geneN: number of all possible genes
+
+  pvalue_list <- c()
+  # loop through pathway terms
+  for (term in 1:nrow(pathway.terms)) {
+    # get genes in one pathway term
+    term_genes <- unlist(strsplit(pathway.terms[term, 2], ";"))
+   # print(length(gene.set))
+    test_result <- enrich_test(gene.set, term_genes, geneN)
+    # get p value
+    pvalue <- test_result$p.value
+    pvalue_list <- c(pvalue_list, pvalue)
+  }
+  return(pvalue_list)
+}
+
+
+test.one.model <- function(weight_matrix, pathway, HW_cutoff) {
+  # This function tests pathway enrichment for all nodes in an ADAGE model.
+  #
+  # Inputs:
+  # weight_matrix: a data.matrix that stores weights of an ADAGE model
+  # pathway: a data.frame read from the pseudomonas_KEGG_terms.txt
+  # HW_cutoff: the number of standard deviations from mean to be considered as
+  #            high-weight
+  # Output:
+  # pvalue_table: a data.frame that stores the enrichment results between each
+  #               node and each pathway
+
+  nodeN <- ncol(weight_matrix)
+  geneN <- nrow(weight_matrix)
+  print(dim(weight_matrix))
+  pvalue_table <- list()
+  for (node in 1:nodeN) {
+
+    # get high-weight genes at pos and neg sides
+    pos_cutoff <- mean(weight_matrix[, node]) +
+      HW_cutoff * sd(weight_matrix[, node])
+    neg_cutoff <- mean(weight_matrix[, node]) -
+      HW_cutoff * sd(weight_matrix[, node])
+    HW_genes_pos <- rownames(weight_matrix)[weight_matrix[, node] >= pos_cutoff]
+    HW_genes_neg <- rownames(weight_matrix)[weight_matrix[, node] <= neg_cutoff]
+
+    # pathway enrichment analysis for positive high-weight genes
+    print(length(HW_genes_pos))
+    print(length(HW_genes_neg))
+    pvalue_list <- enrichment.test(HW_genes_pos, pathway, geneN)
+    this_table_pos <- data.frame(node = paste("Node", rep(node, nrow(pathway))),
+                                 side = rep("pos", nrow(pathway)),
+                                 pathway = rownames(pathway),
+                                 pvalue = pvalue_list)
+
+    # pathway enrichment analysis for negative high-weight genes
+    pvalue_list <- enrichment.test(HW_genes_neg, pathway, geneN)
+    this_table_neg <- data.frame(node = paste("Node", rep(node, nrow(pathway))),
+                                 side = rep("neg", nrow(pathway)),
+                                 pathway = rownames(pathway),
+                                 pvalue = pvalue_list)
+
+    # combine pos and neg sides
+    this_table <- rbind(this_table_pos, this_table_neg)
+
+    # FDR correction
+    this_table$pvalue <- as.numeric(as.character(this_table$pvalue))
+    this_table$qvalue <- p.adjust(this_table$pvalue, method = "fdr")
+    pvalue_table[[node]] <- this_table
+  }
+  pvalue_table <- do.call(rbind, pvalue_table)
+
+  return (pvalue_table)
+}
+
+
+one.pathway.analysis <- function(netfile, geneID, pathway, outfile1,
+                                 outfile2, HW_cutoff, sig_cutoff,
+                                 component = FALSE, output_all = FALSE){
+  # This function reads in an ADAGE model from a file, performs pathway
+  # enrichment analysis, and write the output into files.
+  #
+  # Inputs:
+  # netfile: file path to the network file of an ADAGE model
+  # geneID: the gene IDs that correspond to each row of an ADAGE weight matrix
+  # pathway: a data.frame read from the pseudomonas_KEGG_terms.txt
+  # outfile1: file path to output file that stores only significant enrichment
+  #           results
+  # outfile2: file path to output file that stores all tested node-pathway
+  #           associations
+  # HW_cutoff: float, number of standard deviations from mean to be considered
+  #            as high-weight
+  # sig_cutoff: float, significance cutoff of FDR q-values
+  # component: boolean, whether each column in the weight matrix represent a
+  #            component in PCA or ICA model
+  # output_all: boolean, whether to write outfile2 that stores every enrichment
+  #             test
+  print('one.pathway.analysis')
+  # load the weight matrix
+  geneN = nrow(geneID)
+  weight = read_delim(netfile, delim = ',', col_names = F, n_max = geneN,
+                      skip = 0)
+  #weight = read_delim(netfile, delim = '\t', col_names = F, n_max = geneN,
+  #                    skip = 4)
+  print(dim(weight))
+  print(weight[1,1])
+  weight_matrix <- data.matrix(weight[1:geneN, ])
+  rownames(weight_matrix) = geneID$X
+  print(geneID$X[1])
+  # test pathway association between all nodes in a model and all pathways
+  print(dim(pathway))
+  print(pathway[1,1])
+  pvalue_table <- test.one.model(weight_matrix, pathway, HW_cutoff)
+  print(dim(pvalue_table))
+  if (component) {
+    # rename node to component for PCA and ICA models
+    colnames(pvalue_table)[1] = 'component'
+  }
+
+  # get significant results and write to file
+  pvalue_table_sig = pvalue_table[which(pvalue_table$qvalue <= sig_cutoff), ]
+  print(dim(pvalue_table_sig))
+  write.table(pvalue_table_sig, outfile1, col.names = T, row.names = F,
+              quote = F, sep = '\t')
+
+  if (output_all) {
+    # output all results including non significant associations
+    write.table(pvalue_table, outfile2, col.names = T, row.names = F, quote = F,
+                sep = '\t')
+  }
+}
+
+
+multi.pathway.analysis <- function(netfiles, data_file, pathway_file, outfile1,
+                                   outfile2, output_all, type,
+                                   HW_cutoff = 2.5, sig_cutoff = 0.05) {
+  # This function handles multiple ADAGE network files together. It is designed
+  # to perform pathway enrichment analyses for models with different model
+  # sizes (type="netsize"), or trained with different number of samples
+  # (type="subsample"), or multiple ensemble models (type="ensemble"). It will
+  # assemble enrichment results with meta data and write to output files.
+  #
+  # Inputs:
+  # netfiles: file paths to network files of ADAGE models to be analyzed
+  # data_file: file path to the input data compendium that are used to build
+  #            those ADAGE models
+  # pathway_file: file path to the pathway annotation file
+  #               pseudomonas_KEGG_terms.txt
+  # outfile1: file path to output file that stores only significant enrichment
+  #           results
+  # outfile2: file path to output file that stores all tested node-pathway
+  #           associations
+  # output_all: boolean, whether to write outfile2 that stores every enrichment
+  #             test
+  # type: can be "netsize", "corruption", "subsample", "ensemble", or
+  #       "ensembleSize", it determines how the meta data are recorded
+  # HW_cutoff: float, number of standard deviations from mean to be considered
+  #            as high-weight
+  # sig_cutoff: float, significance cutoff of FDR q-values
+
+
+  # check input analysis type
+  if (!type %in% c("netsize", "corruption", "subsample", "ensemble",
+                   "ensembleSize")){
+    stop("Analysis type unknown! Must be netsize, corruption, subsample,
+         ensemble, or ensembleSize.")
+  }
+
+  # count the number of columns in the data file
+  col_n <- count.fields(data_file, sep = ",")[1]
+  # read in the gene IDs from data file
+  geneID <- read.table(data_file, sep = ",", header = T,
+                       colClasses = c("character", rep("NULL", col_n - 1)))
+  geneN <- nrow(geneID)
+  # read in pathway terms
+  pathway <- read.table(pathway_file, sep = "\t", header = F, row.names = 1,
+                        stringsAsFactors = F)
+
+  # the pathway enrichment analysis for each network file runs in parallel
+  all_path <- foreach(i = 1:length(netfiles), .combine = "rbind") %dopar% {
+
+    weight = read_delim(netfiles[i], delim = '\t', col_names = F, n_max = geneN,
+                        skip = 2)
+    weight_matrix <- data.matrix(weight[1:geneN, ])
+    rownames(weight_matrix) <- geneID$Gene_symbol
+
+    pvalue_table <- test.one.model(weight_matrix, pathway, HW_cutoff)
+
+    # get the parameter info from file name
+    parameter_info <- unlist(strsplit(basename(netfiles[i]), "_"))
+    if (type == "subsample") {
+      seed1 <- parameter_info[8]
+      seed2 <- parameter_info[10]
+      samplesize <- parameter_info[12]
+      pvalue_table <- data.frame(samplesize = rep(samplesize, nrow(pvalue_table)),
+                                 seed2 = rep(seed1, nrow(pvalue_table)),
+                                 seed1 = rep(seed2, nrow(pvalue_table)),
+                                 pvalue_table)
+    } else if (type == "netsize") {
+      seed <- parameter_info[8]
+      pvalue_table <- data.frame(seed = rep(seed, nrow(pvalue_table)),
+                                 pvalue_table)
+    } else if (type == "corruption") {
+      seed <- parameter_info[8]
+      corruption <- parameter_info[5]
+      pvalue_table <- data.frame(seed = rep(seed, nrow(pvalue_table)),
+                                 corruption = rep(corruption, nrow(pvalue_table)),
+                                 pvalue_table)
+    } else if (type == "ensemble") {
+      model  <- parameter_info[3]
+      seed <- parameter_info[6]
+      pvalue_table <- data.frame(model = rep(model, nrow(pvalue_table)),
+                                 seed = rep(seed, nrow(pvalue_table)),
+                                 pvalue_table)
+    } else if (type == "ensembleSize") {
+      ensembleSize  <- parameter_info[4]
+      seed <- parameter_info[6]
+      pvalue_table <- data.frame(ensembleSize = rep(ensembleSize,
+                                                    nrow(pvalue_table)),
+                                 seed = rep(seed, nrow(pvalue_table)),
+                                 pvalue_table)
+    }
+
+    pvalue_table
+  }
+
+  all_path$qvalue <- as.numeric(all_path$qvalue)
+  sig_path <- all_path[which(all_path$qvalue <= sig_cutoff), ]
+  # write the significant result table
+  write.table(sig_path, outfile1, col.names = TRUE, row.names = FALSE,
+              quote = FALSE, sep = "\t")
+  if (output_all) {
+    # write the complete result table
+    write.table(all_path, outfile2, col.names = TRUE, row.names = FALSE,
+                quote = FALSE, sep = "\t")
+  }
+}
+


### PR DESCRIPTION
I updated the seqADAGE jupyter notebook to compare training the same array compendium using TF from adage source code and new keras script, including node KEGG enrichments for comparisons.